### PR TITLE
Add travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 sudo: false
 
 # We don't care about Travis' python versions, we install conda anyway
-python:
-  - 3.4
-
 env:
   - CONDA_PYTHON_VERSION=3.5
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,9 @@ install:
   - conda create --yes -n test-environment python=$TRAVIS_PYTHON_VERSION 
   - source activate test-environment
   - conda install -c https://conda.anaconda.org/babbel boto3 pytest pytest-mock pytest-pythonpath
-  - export AWS_DEFAULT_REGION="eu-west-1"
 
 script:
   - py.test -vv -r sxX
 
 notifications:
-  email: false
+  email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,14 @@
 language: python
 sudo: false
 
+# We don't care about Travis' python versions, we install conda anyway
 python:
-- 3.5
+  - 3.4
 
-install:
+env:
+  - CONDA_PYTHON_VERSION=3.5
+
+before_install:
   # Install conda
   - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -12,9 +16,10 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda update conda
 
+install:
   # Install dependencies
-  - conda create --yes -n test-environment python=$TRAVIS_PYTHON_VERSION 
-  - source activate test-environment
+  - conda create --yes -n testenv_$CONDA_PYTHON_VERSION python=$CONDA_PYTHON_VERSION 
+  - source activate testenv_$CONDA_PYTHON_VERSION
   - conda install -c https://conda.anaconda.org/babbel boto3 pytest pytest-mock pytest-pythonpath
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+language: python
+sudo: false
+
+python:
+- 3.5
+
+install:
+  # Install conda
+  - wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update conda
+
+  # Install dependencies
+  - conda create --yes -n test-environment python=$TRAVIS_PYTHON_VERSION 
+  - source activate test-environment
+  - conda install -c https://conda.anaconda.org/babbel boto3 pytest pytest-mock pytest-pythonpath
+  - export AWS_DEFAULT_REGION="eu-west-1"
+
+script:
+  - py.test -vv -r sxX
+
+notifications:
+  email: false


### PR DESCRIPTION
Add basic travis CI for testing.

Since Travis doesn't have Python 3.5 preinstalled, we totally ignore Travis' python version

Instead of 

```
python:
  - 3.5
...
  - conda create --yes -n test-environment python=$TRAVIS_PYTHON_VERSION
```

We do

```
env:
  - CONDA_PYTHON_VERSION=3.5
...
- conda create --yes -n testenv_$CONDA_PYTHON_VERSION python=$CONDA_PYTHON_VERSION 
```

This doesn't save much, but a little time.
