### PR TITLE
add global env AWS_DEFAULT_REGION, so that PRs work from forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ sudo: false
 
 # We don't care about Travis' python versions, we install conda anyway
 env:
-  - CONDA_PYTHON_VERSION=3.5
-  - AWS_DEFAULT_REGION=eu-west-1
+  global:
+    - AWS_DEFAULT_REGION=eu-west-1
+  matrix:
+    - CONDA_PYTHON_VERSION=3.5
 
 before_install:
   # Install conda


### PR DESCRIPTION
This adds an environment variable `AWS_DEFAULT_REGION=eu-west-1` in travis.yml,
that will be used for all envs in the build matrix,

See
https://docs.travis-ci.com/user/environment-variables/#Global-Variables
