### PR TITLE
Child workflow 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,7 @@ docs/_build/
 # PyBuilder
 target/
 
+# Vim
+*.swp
 secrets.py
 .hypothesis

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/babbel/floto.svg?branch=master)](https://travis-ci.com/babbel/floto)
+
 # floto
 floto is a task orchestration tool based on AWS SWF (Simple Workflow Service) written in Python. It uses Python 3 and boto3, the AWS SDK for Python.
 
@@ -60,7 +62,7 @@ activity_task_b = ActivityTask(name='ActivityB', version='v1')
 activity_task_c = ActivityTask(name='ActivityC', version='v1', requires=[activity_task_a, activity_task_b])
 
 decider_spec = DeciderSpec(domain='your_domain',
-                           task_list='your_decider_task_list'),
+                           task_list='your_decider_task_list',
                            activity_task_list='your_activity_task_list',
                            activity_tasks=[activity_task_a, activity_task_b, activity_task_c])
 

--- a/examples/child_workflow/activities.py
+++ b/examples/child_workflow/activities.py
@@ -1,0 +1,58 @@
+import floto
+import logging
+import random
+
+logger = logging.getLogger(__name__)
+
+domain = 'floto_test'
+activity_task_list = 'demo_step_activities_philipp'
+
+# ---------------------------------- #
+# Create the activity functions
+# ---------------------------------- #
+# Register floto activities. The context parameter carries the input information. The context
+# parameter is not mandatory.
+@floto.activity(name='demo_step1', version='v2')
+def step1(context):
+    logger.debug('Running set_random_number. Context: ', context)
+    print(context)
+    try:
+        startval = context['workflow'].get('start_val')
+    except KeyError:
+        startval = 0
+        pass
+
+    result = startval + random.randint(5, 60)
+    return {'result': result}
+
+
+@floto.activity(name='demo_step2', version='v2')
+def step2(context):
+    logger.debug('Running add_random_number. Context: ', context)
+    print(context)
+    result = random.randint(0, 10000)
+    return {'result': result}
+
+@floto.activity(name='demo_step3', version='v2')
+def step3(context):
+    logger.debug('Running add_random_number. Context: ', context)
+    print(context)
+    result = random.randint(3, 9)
+    return {'result': result}
+
+@floto.activity(name='demo_step4', version='v1')
+def step4(context):
+    logger.debug('Generating spec for child_workflow. Context: ', context)
+
+    results_step2 = [v['result'] for k,v in context.items() if 'demo_step2' in k]
+
+    activity_tasks = [floto.specs.ActivityTask(name='demo_step2', version='v2', 
+        input={'start_val':start_val}) for start_val in results_step2]
+
+    decider_spec = floto.specs.DeciderSpec(activity_tasks=activity_tasks)
+
+    return {'decider_spec':decider_spec.to_json()}
+
+
+worker_1 = floto.ActivityWorker(domain=domain, task_list=activity_task_list)
+worker_1.run()

--- a/examples/child_workflow/child_decider.py
+++ b/examples/child_workflow/child_decider.py
@@ -1,0 +1,24 @@
+import floto
+import logging
+from floto.specs import ActivityTask, DeciderSpec, ChildWorkflow
+import floto.decider
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------- #
+# Create Activity Tasks and Decider
+# ---------------------------------- #
+rs = floto.specs.retry_strategy.InstantRetry(retries=2)
+a2 = ActivityTask(name='demo_step2', version='v2', retry_strategy=rs)
+
+decider_spec = DeciderSpec(domain='floto_test',
+                           task_list='demo_step_decisions_child',
+                           activity_task_list='demo_step_activities_philipp',
+                           terminate_decider_after_completion=False)
+
+decider = floto.decider.DynamicDecider(decider_spec=decider_spec)
+
+# ---------------------------------- #
+# Start the decider
+# ---------------------------------- #
+decider.run()

--- a/examples/child_workflow/child_decider.py
+++ b/examples/child_workflow/child_decider.py
@@ -8,9 +8,6 @@ logger = logging.getLogger(__name__)
 # ---------------------------------- #
 # Create Activity Tasks and Decider
 # ---------------------------------- #
-rs = floto.specs.retry_strategy.InstantRetry(retries=2)
-a2 = ActivityTask(name='demo_step2', version='v2', retry_strategy=rs)
-
 decider_spec = DeciderSpec(domain='floto_test',
                            task_list='demo_step_decisions_child',
                            activity_task_list='demo_step_activities_philipp',

--- a/examples/child_workflow/decider.py
+++ b/examples/child_workflow/decider.py
@@ -1,0 +1,33 @@
+import floto
+import logging
+from floto.specs import ActivityTask, DeciderSpec, ChildWorkflow
+import floto.decider
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------- #
+# Create Activity Tasks and Decider
+# ---------------------------------- #
+rs = floto.specs.retry_strategy.InstantRetry(retries=2)
+a1 = ActivityTask(name='demo_step1', version='v2', retry_strategy=rs)
+a2 = ActivityTask(name='demo_step2', version='v2', requires=[a1], retry_strategy=rs, 
+        input={'start_val': 1} )
+a2a = ActivityTask(name='demo_step2', version='v2', requires=[a1], retry_strategy=rs, 
+        input={'start_val': 2} )
+a4 = ActivityTask(name='demo_step4', version='v1', requires=[a2, a2a], retry_strategy=rs)
+
+cw1 = ChildWorkflow(workflow_type_name='demo_flow_child_workflow', workflow_type_version='v1', 
+        task_list='demo_step_decisions_child', requires=[a4], retry_strategy=rs)
+
+decider_spec = DeciderSpec(domain='floto_test',
+                           task_list='demo_step_decisions_philipp',
+                           activity_tasks=[a1, a2, a2a, a4, cw1],
+                           activity_task_list='demo_step_activities_philipp',
+                           terminate_decider_after_completion=False)
+
+decider = floto.decider.Decider(decider_spec=decider_spec)
+
+# ---------------------------------- #
+# Start the decider
+# ---------------------------------- #
+decider.run()

--- a/examples/child_workflow/register_types.py
+++ b/examples/child_workflow/register_types.py
@@ -1,0 +1,37 @@
+import floto
+
+swf = floto.api.Swf()
+
+## Define and register a workflow type.
+workflow_type = floto.api.WorkflowType(domain='floto_test', name='demo_flow', version='v2', 
+        default_task_start_to_close_timeout='7')
+swf.register_workflow_type(workflow_type)
+
+child_workflow_type = floto.api.WorkflowType(domain='floto_test', name='demo_flow_child_workflow', 
+        version='v1', default_task_start_to_close_timeout='7')
+swf.register_workflow_type(child_workflow_type)
+
+## Define and register an activity type
+activity_type = floto.api.ActivityType(name='demo_step1', version='v2', domain='floto_test', 
+        default_task_heartbeat_timeout='5')
+swf.register_activity_type(activity_type)
+
+## Define and register an activity type
+activity_type = floto.api.ActivityType(name='demo_step2', version='v2', domain='floto_test', 
+        default_task_heartbeat_timeout='5')
+swf.register_activity_type(activity_type)
+
+## Define and register an activity type
+activity_type = floto.api.ActivityType(name='demo_step3', version='v2', domain='floto_test', 
+        default_task_heartbeat_timeout='5')
+swf.register_activity_type(activity_type)
+
+activity_type = floto.api.ActivityType(name='demo_step4', version='v1', domain='floto_test', 
+        default_task_heartbeat_timeout='5')
+swf.register_activity_type(activity_type)
+
+activity_type = floto.api.ActivityType(name='demo_step5', version='v1', domain='floto_test', 
+        default_task_heartbeat_timeout='5')
+swf.register_activity_type(activity_type)
+
+

--- a/examples/child_workflow/start_workflow.py
+++ b/examples/child_workflow/start_workflow.py
@@ -1,0 +1,13 @@
+import floto
+
+# ---------------------------------- #
+# Start the workflow execution
+# ---------------------------------- #
+workflow_args = {'domain': 'floto_test', 
+                 'workflow_type_name': 'demo_flow',
+                 'workflow_type_version': 'v2',
+                 'task_list': 'demo_step_decisions_philipp',
+                 'workflow_id': 'demo_flow5',
+                 'input': {'start_val': 55}}
+
+response = floto.api.Swf().start_workflow_execution(**workflow_args)

--- a/floto/activity_worker.py
+++ b/floto/activity_worker.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import socket
 import sys
 from inspect import signature
 
@@ -22,18 +23,22 @@ class ActivityWorker:
     my_activity_worker.run()
     """
 
-    def __init__(self, swf=None, task_list=None, domain=None, task_heartbeat_in_seconds=None):
+    def __init__(self, swf=None, task_list=None, domain=None, task_heartbeat_in_seconds=None, identity=None):
         """
         Parameters
         ----------
-        swf: floto.api.Swf()
+        swf: Optional[floto.api.Swf]
             If None a new instance is initiated
-        task_list: str [Required]
+        task_list: str
             The task_list of the activity worker
-        domain: str [Required]
-        task_heartbeat_in_seconds: int
+        domain: str
+        task_heartbeat_in_seconds: Optional[int]
             Heartbeats are sent every <task_heartbeat_in_seconds> to SWF during the execution. If
             set to 0 no heartbeats will be sent. Default is 120.
+        identity: Optional[str]
+            Identity of the worker making the request, recorded in the ActivityTaskStarted event in
+            the workflow history. This enables diagnostic tracing when problems arise. The form of
+            this identity is user defined. Default is the fully qualified domain name.
         """
         self.task_token = None
         self.last_response = None
@@ -45,13 +50,19 @@ class ActivityWorker:
         self.task_list = task_list
         self.domain = domain
         self.task_heartbeat_in_seconds = task_heartbeat_in_seconds
-        if self.task_heartbeat_in_seconds == None:
+        if self.task_heartbeat_in_seconds is None:
             self.task_heartbeat_in_seconds = 120
+
+        self.identity = identity
+        if self.identity is None:
+            self.identity = socket.getfqdn(socket.gethostname())
+
         self.heartbeat_sender = floto.HeartbeatSender()
 
     def poll(self):
         self.last_response = self.swf.poll_for_activity_task(domain=self.domain,
-                                                             task_list=self.task_list)
+                                                             task_list=self.task_list,
+                                                             identity=self.identity)
         if 'taskToken' in self.last_response:
             self.task_token = self.last_response['taskToken']
         else:

--- a/floto/activity_worker.py
+++ b/floto/activity_worker.py
@@ -60,6 +60,7 @@ class ActivityWorker:
         self.heartbeat_sender = floto.HeartbeatSender()
 
     def poll(self):
+        logger.debug('ActivityWorker.poll...')
         self.last_response = self.swf.poll_for_activity_task(domain=self.domain,
                                                              task_list=self.task_list,
                                                              identity=self.identity)
@@ -69,6 +70,7 @@ class ActivityWorker:
             self.task_token = None
 
     def run(self):
+        logger.debug('ACTIVITY_FUNCS: {}'.format(floto.ACTIVITY_FUNCTIONS))
         number_polls = 0
         while (not self.get_terminate_activity_worker()) and (number_polls < self.max_polls):
             self.poll()
@@ -110,12 +112,14 @@ class ActivityWorker:
         return self._terminate_activity_worker
 
     def task_failed(self, error):
+        logger.debug('ActivityWorker.task_failed...')
         self.swf.client.respond_activity_task_failed(taskToken=self.task_token, details=str(error))
 
     def terminate_worker(self):
         self._terminate_activity_worker = True
 
     def complete(self):
+        logger.debug('ActivityWorker.complete...')
         args = {'taskToken': self.task_token}
         if self.result and isinstance(self.result, str):
             args['result'] = self.result
@@ -124,10 +128,12 @@ class ActivityWorker:
         self.swf.client.respond_activity_task_completed(**args)
 
     def start_heartbeat(self):
+        logger.debug('ActivityWorker.start_heartbeat...')
         args = {'timeout': self.task_heartbeat_in_seconds,
                 'task_token': self.task_token}
         if self.task_heartbeat_in_seconds:
             self.heartbeat_sender.send_heartbeats(**args)
 
     def stop_heartbeat(self):
+        logger.debug('ActivityWorker.start_heartbeat...')
         self.heartbeat_sender.stop_heartbeats()

--- a/floto/api/swf.py
+++ b/floto/api/swf.py
@@ -48,7 +48,8 @@ class Swf(object):
 
         args = {'domain': domain,
                 'taskList': {'name': task_list},
-                'reverseOrder': True}
+                'reverseOrder': True
+                }
         if page_token:
             args['nextPageToken'] = page_token
 

--- a/floto/api/swf.py
+++ b/floto/api/swf.py
@@ -56,9 +56,10 @@ class Swf(object):
 
         return self.client.poll_for_decision_task(**args)
 
-    def poll_for_activity_task(self, domain, task_list):
+    def poll_for_activity_task(self, domain, task_list, identity='NA'):
         args = {'domain': domain,
-                'taskList': {'name': task_list}}
+                'taskList': {'name': task_list},
+                'identity': identity}
         return self.client.poll_for_activity_task(**args)
 
     def register_activity_type(self, swf_type):

--- a/floto/decider/__init__.py
+++ b/floto/decider/__init__.py
@@ -2,4 +2,5 @@ from .base import Base
 from .decider import Decider
 from .execution_graph import ExecutionGraph
 from .daemon import Daemon
+from .decision_input import DecisionInput
 from .decision_builder import DecisionBuilder

--- a/floto/decider/__init__.py
+++ b/floto/decider/__init__.py
@@ -1,5 +1,6 @@
 from .base import Base
 from .decider import Decider
+from .dynamic_decider import DynamicDecider
 from .execution_graph import ExecutionGraph
 from .daemon import Daemon
 from .decision_input import DecisionInput

--- a/floto/decider/base.py
+++ b/floto/decider/base.py
@@ -36,6 +36,7 @@ class Base:
         self._separate_process = None
 
     def complete(self):
+        logger.debug('Base.complete...')
         decisions = [d.get_decision() for d in self.decisions]
         try:
             self.swf.client.respond_decision_task_completed(taskToken=self.task_token,
@@ -64,6 +65,7 @@ class Base:
                                          response=self.last_response)
             self.run_id = self.last_response['workflowExecution']['runId']
             self.workflow_id = self.last_response['workflowExecution']['workflowId']
+            logger.debug('Found task token')
         else:
             self.history = None
             self.task_token = None
@@ -80,6 +82,7 @@ class Base:
             self._run()
 
     def _run(self):
+        # TODO remove poll counting before use in prodcuction
         number_polls = 0
         while (not self.terminate_decider) and (number_polls < self.max_polls):
             self.poll_for_decision()
@@ -88,6 +91,7 @@ class Base:
             if self.task_token:
                 self.get_decisions()
                 self.complete()
+        logger.debug('Base._run ended. Polls: {}'.format(number_polls))
 
     def get_workflow_execution_description(self):
         return self.swf.describe_workflow_execution(self.domain, self.workflow_id, self.run_id)

--- a/floto/decider/decider.py
+++ b/floto/decider/decider.py
@@ -55,9 +55,10 @@ class Decider(Base):
                     'workflow_type_name': execution_info['workflowType']['name'],
                     'workflow_type_version': execution_info['workflowType']['version'],
                     'task_list': self.task_list,
-                    'input': self.decision_builder.workflow_input}
+                    'input': self.decision_builder.decision_input.get_input_workflow()}
             self.swf.start_workflow_execution(**args)
             self.terminate_workflow = False
             self.terminate_decider = False
         else:
             self.terminate_decider = True
+

--- a/floto/decider/decider.py
+++ b/floto/decider/decider.py
@@ -60,5 +60,5 @@ class Decider(Base):
             self.terminate_workflow = False
             self.terminate_decider = False
         else:
-            self.terminate_decider = True
+            self.terminate_decider = self.decider_spec.terminate_decider_after_completion
 

--- a/floto/decider/decider.py
+++ b/floto/decider/decider.py
@@ -31,7 +31,12 @@ class Decider(Base):
         self.repeat_workflow = self.decider_spec.repeat_workflow
         self.activity_task_list = self.decider_spec.activity_task_list or 'floto_activities'
 
-        activity_tasks = self.decider_spec.activity_tasks
+        self.decision_builder = None
+
+        if self.decider_spec.activity_tasks:
+            self._init_decision_builder(self.decider_spec.activity_tasks)
+
+    def _init_decision_builder(self, activity_tasks):
         execution_graph = floto.decider.ExecutionGraph(activity_tasks)
         self.decision_builder = floto.decider.DecisionBuilder(execution_graph,
                                                               self.activity_task_list)

--- a/floto/decider/decider.py
+++ b/floto/decider/decider.py
@@ -1,9 +1,12 @@
+import logging
+
 import floto
 import floto.api
 import floto.decisions
 import floto.specs
 from floto.decider import Base
 
+logger = logging.getLogger(__name__)
 
 class Decider(Base):
     """Decider which is defined by a DeciderSpec object 
@@ -14,7 +17,7 @@ class Decider(Base):
        For definition of decider spec see floto.specs.DeciderSpec
     """
 
-    def __init__(self, decider_spec=None):
+    def __init__(self, decider_spec=None, identity=None):
         super().__init__()
 
         if isinstance(decider_spec, str):
@@ -40,6 +43,7 @@ class Decider(Base):
         """Heart of the decider logics. Called by floto.decider.Base in each 
         'poll_for_decision_taks loop'. Fills self.decisions, which are returned to SWF.
         """
+        logger.debug('Decider.get_decisions...')
         # TODO: redesign desc
         desc = self.get_workflow_execution_description()
         self.decision_builder.current_workflow_execution_description = desc
@@ -49,7 +53,9 @@ class Decider(Base):
     def tear_down(self):
         """If self.reapeat_workflow is True, the workflow is restarted after successful
         completion."""
+        logger.debug('Decider.tear_down...')
         if self.repeat_workflow:
+            logger.debug('Decider.tear_down: repeat...')
             execution_info = self.get_workflow_execution_description()['executionInfo']
             args = {'domain': self.domain,
                     'workflow_type_name': execution_info['workflowType']['name'],
@@ -60,5 +66,6 @@ class Decider(Base):
             self.terminate_workflow = False
             self.terminate_decider = False
         else:
+            logger.debug('Decider.tear_down: terminate')
             self.terminate_decider = self.decider_spec.terminate_decider_after_completion
 

--- a/floto/decider/decision_builder.py
+++ b/floto/decider/decision_builder.py
@@ -26,7 +26,6 @@ class DecisionBuilder:
         decisions = self._collect_decisions(first_event_id, last_event_id)
         return decisions
 
-    #TODO test
     def _set_history(self, history):
         self.history = history
         self.decision_input.history = history
@@ -55,23 +54,11 @@ class DecisionBuilder:
             decisions.extend(self.get_decisions_decision_failed(events['decision_failed']))
         return decisions
 
-    # TODO test
     def get_decisions_after_workflow_start(self):
         decisions = []
         tasks = self.execution_graph.get_first_tasks()
         for t in tasks:
             decision = self.get_decision_schedule_activity(t)
-            #if isinstance(t, floto.specs.ActivityTask):
-                #input_ = self.decision_input.get_input_task(t, add_workflow_input=True)
-                #decision = self.get_decision_schedule_activity_task(activity_task=t, input=input_)
-            #elif isinstance(t, floto.specs.Timer):
-                #decision = self.get_decision_start_timer(t)
-            #elif isinstance(t, floto.specs.ChildWorkflow):
-                #input_ = self.decision_input.get_input_task(t, add_workflow_input=True)
-                #decision = self.get_decision_start_child_workflow_execution(child_workflow_task=t,
-                        #input_=input_)
-            #else:
-                #raise ValueError('Unknown task type: {}'.format(t))
             decisions.append(decision)
         return decisions
 
@@ -100,8 +87,6 @@ class DecisionBuilder:
             if t.retry_strategy:
                 failures = self.history.get_number_activity_failures(t)
                 if t.retry_strategy.is_task_resubmitted(failures):
-                    # TODO test 
-                    # TODO current marker
                     decision = self.get_decision_schedule_activity(t, is_failed_task=True)
                     decisions.append(decision)
                 else:
@@ -143,7 +128,6 @@ class DecisionBuilder:
         self.workflow_complete = True
         return [d]
 
-    # TODO test
     def get_decision_schedule_activity(self, task, is_failed_task=False):
         if isinstance(task, floto.specs.ActivityTask):
             input_ = self.decision_input.get_input_task(task, is_failed_task)
@@ -161,23 +145,6 @@ class DecisionBuilder:
         d = floto.decisions.FailWorkflowExecution(details=details, reason=reason)
         self.workflow_fail = True
         return [d]
-
-    # TODO remove
-    #def get_decision_task(self, task):
-        #"""Return a single decision for an ActivityTask or a Timer
-        #Parameters
-        #----------
-        #task: floto.specs.ActivityTask or floto.specs.Timer
-
-        #Returns
-        #-------
-        #floto.decision.ScheduleActivityTask of floto.decision.StartTimer
-        #"""
-        #if isinstance(task, floto.specs.ActivityTask):
-            #input_ = self.decision_input.get_input_task_with_dependencies(task)
-            #return self.get_decision_schedule_activity_task(task, input_)
-        #elif isinstance(task, floto.specs.Timer):
-            #return self.get_decision_start_timer(task)
 
     def get_decision_schedule_activity_task(self, activity_task=None, input=None):
         activity_type = floto.api.ActivityType(name=activity_task.name,

--- a/floto/decider/decision_builder.py
+++ b/floto/decider/decision_builder.py
@@ -1,8 +1,11 @@
-import json
 
 import floto
 import floto.decisions
 import floto.specs
+
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class DecisionBuilder:
@@ -34,6 +37,7 @@ class DecisionBuilder:
         return self.workflow_fail or self.workflow_complete
 
     def _collect_decisions(self, first_event_id, last_event_id):
+        logger.debug('DecisionBuilder._collect_decisions({},{})'.format(first_event_id, last_event_id))
         if first_event_id == 0:
             return self.get_decisions_after_workflow_start()
 
@@ -55,6 +59,7 @@ class DecisionBuilder:
         return decisions
 
     def get_decisions_after_workflow_start(self):
+        logger.debug('DecisionBuilder.get_decisions_after_workflow_start()')
         decisions = []
         tasks = self.execution_graph.get_first_tasks()
         for t in tasks:
@@ -106,6 +111,7 @@ class DecisionBuilder:
         events: list
             List of ActivityTaskCompleted or TimerFired events
         """
+        logger.debug('DecisionBuilder.get_decisions_after_activity_completion...')
         task_ids = [self.history.get_id_task_event(e) for e in events]
         tasks = self.get_tasks_to_be_scheduled(task_ids)
 
@@ -159,6 +165,7 @@ class DecisionBuilder:
                                           start_to_fire_timeout=timer_task.delay_in_seconds)
 
     def get_decision_start_child_workflow_execution(self, child_workflow_task=None, input_=None):
+        logger.debug('DecisionBuilder.get_decision_start_child_workflow_execution...')
         workflow_type = floto.api.WorkflowType(name=child_workflow_task.workflow_type_name,
                 version=child_workflow_task.workflow_type_version)
         args = {'workflow_id':child_workflow_task.id_,
@@ -171,6 +178,7 @@ class DecisionBuilder:
 
     def all_workflow_tasks_finished(self, completed_tasks):
         """Return True if all tasks of this workflow have finished, False otherwise."""
+        logger.debug('DecisionBuilder.all_workflow_tasks_finished({})'.format((completed_tasks)))
         if self.completed_have_depending_tasks(completed_tasks):
             return False
         if self.open_task_counts():
@@ -182,6 +190,7 @@ class DecisionBuilder:
     def completed_have_depending_tasks(self, completed_tasks):
         """Return True if any of the tasks in "completed_tasks" has a task which depends on it.
         False otherwise."""
+        logger.debug('DecisionBuilder.completed_have_depending_tasks({})'.format((completed_tasks)))
         for t in completed_tasks:
             id_ = self.history.get_id_task_event(t)
             depending_tasks = self.execution_graph.get_depending_tasks(id_)
@@ -225,6 +234,7 @@ class DecisionBuilder:
         list: floto.specs.Task
             The tasks to be scheduled in the next decision
         """
+        logger.debug('DecisionBuilder.get_tasks_to_be_scheduled({})'.format(completed_tasks))
         tasks = []
         for completed_task in completed_tasks:
             tasks += self.get_tasks_to_be_scheduled_single_id(completed_task)

--- a/floto/decider/decision_builder.py
+++ b/floto/decider/decision_builder.py
@@ -12,18 +12,24 @@ class DecisionBuilder:
         self.execution_graph = execution_graph
         self.history = None
         self.activity_task_list = activity_task_list
-        self.workflow_input = None
         self.current_workflow_execution_description = None
+        self.decision_input = floto.decider.DecisionInput(execution_graph=execution_graph)
 
     def get_decisions(self, history):
-        self.history = history
+        self._set_history(history)
+
         self.workflow_fail = False
         self.workflow_complete = False
-
+     
         first_event_id = self.history.previous_decision_id
         last_event_id = self.history.decision_task_started_event_id
         decisions = self._collect_decisions(first_event_id, last_event_id)
         return decisions
+
+    #TODO test
+    def _set_history(self, history):
+        self.history = history
+        self.decision_input.history = history
 
     def is_terminate_workflow(self):
         return self.workflow_fail or self.workflow_complete
@@ -49,21 +55,29 @@ class DecisionBuilder:
             decisions.extend(self.get_decisions_decision_failed(events['decision_failed']))
         return decisions
 
+    # TODO test
     def get_decisions_after_workflow_start(self):
         decisions = []
         tasks = self.execution_graph.get_first_tasks()
         for t in tasks:
-            if isinstance(t, floto.specs.ActivityTask):
-                input_ = self.get_input_activity_task_after_workflow_start(t)
-                decision = self.get_decision_schedule_activity_task(activity_task=t, input=input_)
-            else:
-                decision = self.get_decision_start_timer(t)
+            decision = self.get_decision_schedule_activity(t)
+            #if isinstance(t, floto.specs.ActivityTask):
+                #input_ = self.decision_input.get_input_task(t, add_workflow_input=True)
+                #decision = self.get_decision_schedule_activity_task(activity_task=t, input=input_)
+            #elif isinstance(t, floto.specs.Timer):
+                #decision = self.get_decision_start_timer(t)
+            #elif isinstance(t, floto.specs.ChildWorkflow):
+                #input_ = self.decision_input.get_input_task(t, add_workflow_input=True)
+                #decision = self.get_decision_start_child_workflow_execution(child_workflow_task=t,
+                        #input_=input_)
+            #else:
+                #raise ValueError('Unknown task type: {}'.format(t))
             decisions.append(decision)
         return decisions
 
     def get_decisions_faulty_tasks(self, task_events):
         """Analyze the faulty tasks and their retry strategies. If a task is to be resubmitted,
-        add a decision to the output
+        add a decision to the output.
 
         Parameters
         ----------
@@ -81,23 +95,22 @@ class DecisionBuilder:
         for e in task_events:
             if self.is_terminate_workflow():
                 break
-            activity_id = self.history.get_id_activity_task_event(e)
-            t = self.execution_graph.tasks_by_id[activity_id]
+            id_ = self.history.get_id_task_event(e)
+            t = self.execution_graph.tasks_by_id[id_]
             if t.retry_strategy:
-                failures = self.history.get_number_activity_task_failures(activity_id)
+                failures = self.history.get_number_activity_failures(t)
                 if t.retry_strategy.is_task_resubmitted(failures):
-                    scheduled_event = self.history.get_event_task_scheduled(activity_id)
-                    attributes = scheduled_event['activityTaskScheduledEventAttributes']
-                    input = json.loads(attributes['input']) if 'input' in attributes else None
-                    decision = self.get_decision_schedule_activity_task(t, input)
+                    # TODO test 
+                    # TODO current marker
+                    decision = self.get_decision_schedule_activity(t, is_failed_task=True)
                     decisions.append(decision)
                 else:
                     reason = 'task_retry_limit_reached'
-                    details = self.get_details_failed_tasks(task_events)
+                    details = self.decision_input.get_details_failed_tasks(task_events)
                     decisions = self.get_decisions_after_failed_workflow_execution(reason, details)
             else:
                 reason = 'task_failed'
-                details = self.get_details_failed_tasks(task_events)
+                details = self.decision_input.get_details_failed_tasks(task_events)
                 decisions = self.get_decisions_after_failed_workflow_execution(reason, details)
         return decisions
 
@@ -113,7 +126,7 @@ class DecisionBuilder:
 
         decisions = []
         for t in tasks:
-            decisions.append(self.get_decision_task(t))
+            decisions.append(self.get_decision_schedule_activity(t))
         return decisions
 
     def get_decisions_decision_failed(self, events_decision_failed):
@@ -125,80 +138,69 @@ class DecisionBuilder:
         return decisions
 
     def get_decisions_after_successfull_workflow_execution(self):
-        result = self.get_workflow_result()
+        result = self.decision_input.get_workflow_result()
         d = floto.decisions.CompleteWorkflowExecution(result=result)
         self.workflow_complete = True
         return [d]
+
+    # TODO test
+    def get_decision_schedule_activity(self, task, is_failed_task=False):
+        if isinstance(task, floto.specs.ActivityTask):
+            input_ = self.decision_input.get_input_task(task, is_failed_task)
+            return self.get_decision_schedule_activity_task(task, input_)
+        elif isinstance(task, floto.specs.ChildWorkflow):
+            input_ = self.decision_input.get_input_task(task, is_failed_task)
+            return self.get_decision_start_child_workflow_execution(task, input_)
+        elif isinstance(task, floto.specs.Timer):
+            return self.get_decision_start_timer(task)
+        else:
+            m = 'Do not know how to get decision for task of type: {}'.format(type(task))
+            raise ValueError(m)
 
     def get_decisions_after_failed_workflow_execution(self, reason, details):
         d = floto.decisions.FailWorkflowExecution(details=details, reason=reason)
         self.workflow_fail = True
         return [d]
 
-    def get_decision_task(self, task):
-        """Return a single decision for an ActivityTask or a Timer
-        Parameters
-        ----------
-        task: floto.specs.ActivityTask or floto.specs.Timer
+    # TODO remove
+    #def get_decision_task(self, task):
+        #"""Return a single decision for an ActivityTask or a Timer
+        #Parameters
+        #----------
+        #task: floto.specs.ActivityTask or floto.specs.Timer
 
-        Returns
-        -------
-        floto.decision.ScheduleActivityTask of floto.decision.StartTimer
-        """
-        if isinstance(task, floto.specs.ActivityTask):
-            input_ = self.get_input_activity_task(task)
-            return self.get_decision_schedule_activity_task(task, input_)
-        elif isinstance(task, floto.specs.Timer):
-            return self.get_decision_start_timer(task)
+        #Returns
+        #-------
+        #floto.decision.ScheduleActivityTask of floto.decision.StartTimer
+        #"""
+        #if isinstance(task, floto.specs.ActivityTask):
+            #input_ = self.decision_input.get_input_task_with_dependencies(task)
+            #return self.get_decision_schedule_activity_task(task, input_)
+        #elif isinstance(task, floto.specs.Timer):
+            #return self.get_decision_start_timer(task)
 
     def get_decision_schedule_activity_task(self, activity_task=None, input=None):
         activity_type = floto.api.ActivityType(name=activity_task.name,
                                                version=activity_task.version)
         decision = floto.decisions.ScheduleActivityTask(activity_type=activity_type,
-                                                        activity_id=activity_task.id_,
-                                                        task_list=self.activity_task_list, input=input)
+                activity_id=activity_task.id_,
+                task_list=self.activity_task_list, input=input)
         return decision
 
     def get_decision_start_timer(self, timer_task):
         return floto.decisions.StartTimer(timer_id=timer_task.id_,
                                           start_to_fire_timeout=timer_task.delay_in_seconds)
 
-    def get_input_activity_task_after_workflow_start(self, task):
-        if not self.workflow_input:
-            self.workflow_input = self.history.get_workflow_input()
-        input_ = {'workflow': self.workflow_input} if self.workflow_input else {}
-        if task.input: input_['activity_task'] = task.input
-        return input_
-
-    def get_input_activity_task(self, task):
-        if task.input:
-            input_ = {'activity_task': task.input}
-        else:
-            input_ = {}
-        dependencies = self.execution_graph.get_dependencies(task.id_)
-        for d in dependencies:
-            result = self.history.get_result_completed_activity(d)
-            if result:
-                input_[d.id_] = result
-        return input_ if input_ else None
-
-    def get_details_failed_tasks(self, failed_tasks_events):
-        details = {}
-        for e in failed_tasks_events:
-            attributes = self.history.get_event_attributes(e)
-            if 'details' in attributes:
-                activity_id = self.history.get_id_activity_task_event(e)
-                details[activity_id] = attributes['details']
-        return details
-
-    def get_workflow_result(self):
-        outgoing_vertices = self.execution_graph.outgoing_vertices()
-        result = {}
-        for task in outgoing_vertices:
-            r = self.history.get_result_completed_activity(task)
-            if r:
-                result[task.id_] = r
-        return result if result else None
+    def get_decision_start_child_workflow_execution(self, child_workflow_task=None, input_=None):
+        workflow_type = floto.api.WorkflowType(name=child_workflow_task.workflow_type_name,
+                version=child_workflow_task.workflow_type_version)
+        args = {'workflow_id':child_workflow_task.id_,
+                'workflow_type':workflow_type}
+        if child_workflow_task.task_list:
+            args['task_list'] = child_workflow_task.task_list
+        if input_:
+            args['input'] = input_
+        return floto.decisions.StartChildWorkflowExecution(**args)
 
     def all_workflow_tasks_finished(self, completed_tasks):
         """Return True if all tasks of this workflow have finished, False otherwise."""
@@ -229,7 +231,10 @@ class DecisionBuilder:
         description = self.current_workflow_execution_description
         open_activity_tasks = description['openCounts']['openActivityTasks']
         open_timers = description['openCounts']['openTimers']
-        if open_activity_tasks or open_timers:
+        open_child_workflows = description['openCounts']['openChildWorkflowExecutions']
+        open_lambda_functions = description['openCounts']['openLambdaFunctions']
+
+        if open_activity_tasks or open_timers or open_child_workflows or open_lambda_functions:
             return True
         return False
 

--- a/floto/decider/decision_input.py
+++ b/floto/decider/decision_input.py
@@ -1,0 +1,87 @@
+import floto.specs
+import json
+
+class DecisionInput:
+    def __init__(self, execution_graph=None):
+        self.history = None
+        self._workflow_input = None
+        self._execution_graph = execution_graph
+
+    def get_input_task(self, task, is_failed_task=False):
+        if isinstance(task, floto.specs.ActivityTask):
+            if is_failed_task:
+                return self._get_input_scheduled_task(task.id_, 'ActivityTaskScheduled')
+            else:
+                return self._get_input(task, 'activity_task')
+        elif isinstance(task, floto.specs.ChildWorkflow):
+            if is_failed_task:
+                return self._get_input_scheduled_task(task.id_, 
+                        'StartChildWorkflowExecutionInitiated')
+            else:
+                return self._get_input(task, 'child_workflow_task')
+        else:
+            return None
+
+    def get_input_workflow(self):
+        if not self._workflow_input:
+            self._workflow_input = self.history.get_workflow_input()
+        return self._workflow_input
+
+    # TODO test with Childworkflow 
+    def get_details_failed_tasks(self, failed_tasks_events):
+        details = {}
+        for e in failed_tasks_events:
+            attributes = self.history.get_event_attributes(e)
+            if 'details' in attributes:
+                activity_id = self.history.get_id_activity_task_event(e)
+                details[activity_id] = attributes['details']
+        return details
+
+    # TODO test with ChildWorkflow 
+    def get_workflow_result(self):
+        outgoing_vertices = self._execution_graph.outgoing_vertices()
+        result = {}
+        for task in outgoing_vertices:
+            r = self.history.get_result_completed_activity(task)
+            if r:
+                result[task.id_] = r
+        return result if result else None
+
+    def _get_input(self, task, input_field_name):
+        input_ = {}
+        dependencies = self._execution_graph.get_dependencies(task.id_)
+        if dependencies:
+            for d in dependencies:
+                result = self.history.get_result_completed_activity(d)
+                if result:
+                    input_[d.id_] = result
+        elif self.get_input_workflow():
+            input_['workflow'] = self.get_input_workflow()
+        if task.input:
+            input_[input_field_name] = task.input
+        return input_ if input_ else None
+
+
+    def _get_input_scheduled_task(self, id_, event_type):
+        scheduled_event = self.history.get_event_by_task_id_and_type(id_, event_type)
+        attributes = self.history.get_event_attributes(scheduled_event)
+        input_ = json.loads(attributes['input']) if 'input' in attributes else None
+        return input_
+
+    # TODO remove
+    #def get_input_task_with_dependencies(self, task):
+        #input_ = self.get_input_task(task)
+        #dependencies = self._execution_graph.get_dependencies(task.id_)
+        #for d in dependencies:
+            #result = self.history.get_result_completed_activity(d)
+            #if result:
+                #input_[d.id_] = result
+        #return input_ if input_ else None
+
+    #def _get_input(self, task, input_field_name, add_workflow_input):
+        #input_ = {}
+        #if add_workflow_input:
+            #input_['workflow'] = self.get_input_workflow()
+        #if task.input:
+            #input_[input_field_name] = task.input
+        #return input_

--- a/floto/decider/decision_input.py
+++ b/floto/decider/decision_input.py
@@ -27,7 +27,6 @@ class DecisionInput:
             self._workflow_input = self.history.get_workflow_input()
         return self._workflow_input
 
-    # TODO test with Childworkflow 
     def get_details_failed_tasks(self, failed_tasks_events):
         details = {}
         for e in failed_tasks_events:
@@ -37,7 +36,6 @@ class DecisionInput:
                 details[activity_id] = attributes['details']
         return details
 
-    # TODO test with ChildWorkflow 
     def get_workflow_result(self):
         outgoing_vertices = self._execution_graph.outgoing_vertices()
         result = {}
@@ -68,20 +66,3 @@ class DecisionInput:
         input_ = json.loads(attributes['input']) if 'input' in attributes else None
         return input_
 
-    # TODO remove
-    #def get_input_task_with_dependencies(self, task):
-        #input_ = self.get_input_task(task)
-        #dependencies = self._execution_graph.get_dependencies(task.id_)
-        #for d in dependencies:
-            #result = self.history.get_result_completed_activity(d)
-            #if result:
-                #input_[d.id_] = result
-        #return input_ if input_ else None
-
-    #def _get_input(self, task, input_field_name, add_workflow_input):
-        #input_ = {}
-        #if add_workflow_input:
-            #input_['workflow'] = self.get_input_workflow()
-        #if task.input:
-            #input_[input_field_name] = task.input
-        #return input_

--- a/floto/decider/decision_input.py
+++ b/floto/decider/decision_input.py
@@ -32,8 +32,8 @@ class DecisionInput:
         for e in failed_tasks_events:
             attributes = self.history.get_event_attributes(e)
             if 'details' in attributes:
-                activity_id = self.history.get_id_activity_task_event(e)
-                details[activity_id] = attributes['details']
+                id_ = self.history.get_id_task_event(e)
+                details[id_] = attributes['details']
         return details
 
     def get_workflow_result(self):

--- a/floto/decider/dynamic_decider.py
+++ b/floto/decider/dynamic_decider.py
@@ -1,0 +1,30 @@
+import floto
+from floto.decider import Decider
+import json
+
+class DynamicDecider(Decider):
+    def __init__(self, decider_spec):
+        super().__init__(decider_spec=decider_spec)
+
+    def get_decisions(self):
+        if not self.decision_builder:
+            spec = self.get_decider_spec_from_input()
+            self._init_decision_builder(spec.activity_tasks)
+
+        desc = self.get_workflow_execution_description()
+        self.decision_builder.current_workflow_execution_description = desc
+
+        self.decisions = self.decision_builder.get_decisions(self.history)
+        self.terminate_workflow = self.decision_builder.is_terminate_workflow()
+
+    def tear_down(self):
+        self.terminate_decider = False
+        self.decision_builder = None
+
+    def get_decider_spec_from_input(self):
+        input_ = self.history.get_workflow_input()
+        for values in input_.values():
+            for k,v in values.items():
+                if 'decider_spec' in k:
+                    return floto.specs.DeciderSpec.from_json(v)
+

--- a/floto/decider/execution_graph.py
+++ b/floto/decider/execution_graph.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 class ExecutionGraph:
     def __init__(self, activity_tasks=None):
         self.tasks = activity_tasks

--- a/floto/decisions/complete_workflow_execution.py
+++ b/floto/decisions/complete_workflow_execution.py
@@ -1,7 +1,9 @@
 import json
 
 from floto.decisions import Decision
+import logging
 
+logger = logging.getLogger(__name__)
 
 class CompleteWorkflowExecution(Decision):
     def __init__(self, result=None):
@@ -9,6 +11,7 @@ class CompleteWorkflowExecution(Decision):
         self.result = result
 
     def _get_decision(self):
+        logger.debug('CompleteWorkflowExecution._get_decision..')
         d = {'decisionType': 'CompleteWorkflowExecution'}
         if self.result:
             d['completeWorkflowExecutionDecisionAttributes'] = {'result': json.dumps(self.result)}

--- a/floto/decisions/fail_workflow_execution.py
+++ b/floto/decisions/fail_workflow_execution.py
@@ -1,6 +1,9 @@
+import logging
+
 import floto
 from floto.decisions import Decision
 
+logger = logging.getLogger(__name__)
 
 class FailWorkflowExecution(Decision):
     def __init__(self, details=None, reason=None):
@@ -13,6 +16,7 @@ class FailWorkflowExecution(Decision):
                 'failWorkflowExecutionDecisionAttributes': self.decision_attributes()}
 
     def decision_attributes(self):
+        logger.debug('FailWorkflowExecution.decision_attributes...')
         a = {}
         if self.details:
             a['details'] = floto.specs.JSONEncoder.dump_object(self.details)

--- a/floto/decisions/schedule_activity_task.py
+++ b/floto/decisions/schedule_activity_task.py
@@ -1,7 +1,9 @@
 import json
+import logging
 
 from floto.decisions import Decision
 
+logger = logging.getLogger(__name__)
 
 class ScheduleActivityTask(Decision):
     def __init__(self, **args):
@@ -21,6 +23,7 @@ class ScheduleActivityTask(Decision):
         return d
 
     def decision_attributes(self):
+        logger.debug('ScheduleActivityTask.decision_attributes...')
         if not self.activity_type:
             raise ValueError('No activity type')
 

--- a/floto/decisions/start_child_workflow_execution.py
+++ b/floto/decisions/start_child_workflow_execution.py
@@ -1,4 +1,5 @@
 from floto.decisions import Decision
+import json
 
 
 class StartChildWorkflowExecution(Decision):
@@ -23,7 +24,7 @@ class StartChildWorkflowExecution(Decision):
             attributes['taskList'] = {'name': args['task_list']}
 
         if 'input' in args:
-            attributes['input'] = args['input']
+            attributes['input'] = json.dumps(args['input'])
 
         self.startChildWorkflowExecutionDecisionAttributes = attributes
 

--- a/floto/decisions/start_child_workflow_execution.py
+++ b/floto/decisions/start_child_workflow_execution.py
@@ -1,6 +1,9 @@
-from floto.decisions import Decision
 import json
+import logging
 
+from floto.decisions import Decision
+
+logger = logging.getLogger(__name__)
 
 class StartChildWorkflowExecution(Decision):
     def __init__(self, **args):
@@ -39,6 +42,7 @@ class StartChildWorkflowExecution(Decision):
         return d
 
     def get_attributes(self):
+        logger.debug('StartChildWorkflowExecution.get_attributes...')
         return self.startChildWorkflowExecutionDecisionAttributes
 
     @property

--- a/floto/history.py
+++ b/floto/history.py
@@ -1,4 +1,8 @@
+import logging
+
 import floto.api
+
+logger = logging.getLogger(__name__)
 
 class History:
     """History provides information based on the events recorded by SWF during the workflow
@@ -375,6 +379,7 @@ class History:
             self._fill_events_by_activity_id(events)
 
     def _collect_new_events_for_fill_by_activity_id(self, event_type, max_event_id):
+        logger.debug('History._collect_new_events_for_fill_by_activity_id...{}, max {}'.format(event_type,max_event_id))
         events = []
         if 'none' in self.events_by_activity_id:
             if event_type in self.events_by_activity_id['none']:
@@ -403,6 +408,7 @@ class History:
                 self.events_by_activity_id[activity_id][event['eventType']].append(event)
 
     def _read_next_event_page(self):
+        logger.debug('History._read_next_event_page...')
         if not self.next_page_token:
             raise ValueError('floto.History._read_next_event_page(): No page token!')
 
@@ -417,6 +423,7 @@ class History:
         self.lowest_event_id = next['events'][-1]['eventId']
 
     def _has_next_event_page(self):
+        logger.debug('History._has_next_event_page...')
         next_page = True
         if not self.next_page_token:
             next_page = False

--- a/floto/specs/__init__.py
+++ b/floto/specs/__init__.py
@@ -2,4 +2,5 @@ from .decider_spec import DeciderSpec
 from .task import Task
 from .activity_task import ActivityTask
 from .timer import Timer
+from .child_workflow import ChildWorkflow
 from .json_encoder import JSONEncoder

--- a/floto/specs/activity_task.py
+++ b/floto/specs/activity_task.py
@@ -24,9 +24,6 @@ class ActivityTask(Task):
         self.name = name
         self.version = version
         self.input = input
-        self.id_ = activity_id or self._default_activity_id()
+        self.id_ = activity_id or self._default_id(name, version, input)
         self.retry_strategy = retry_strategy
 
-    def _default_activity_id(self):
-        input_hash = hash(json.dumps(self.input, sort_keys=True))
-        return '{}:{}:{}'.format(self.name, self.version, input_hash)

--- a/floto/specs/child_workflow.py
+++ b/floto/specs/child_workflow.py
@@ -1,0 +1,44 @@
+from floto.specs import Task
+import json
+
+
+class ChildWorkflow(Task):
+    """ChildWorkflow task spec."""
+
+    def __init__(self, workflow_type_name=None, workflow_type_version=None, workflow_id=None, 
+            requires=None, input=None, task_list=None, retry_strategy=None):
+        """Defines a child workflow which is scheduled as part of a decider execution logic and
+        used in decider specs.
+        
+        Parameters
+        ----------
+        workflow_type_name: str [Required]
+            The name of the workflow type to be scheduled
+        workflow_type_version: str [Required]
+            The version of the workflow type to be scheduled
+        workflow_id: str
+            The id of the workflow. 
+            Defaults to <workflow_type_name>:<workflow_type_version>:hash(input)
+        requires: list
+            List of tasks this child workflow execution depends on
+        input: dict
+            Input provided to this child workflow execution
+        task_list: str
+            The name of the task list to be used for decision tasks of the child workflow 
+            execution. If not set, the default task list of the workflow type is used.
+        retry_strategy: floto.specs.Strategy
+            The strategy which defines the repeated execution strategy.
+        """
+        super().__init__(requires=requires)
+
+        self.workflow_type_name = workflow_type_name
+        self.workflow_type_version = workflow_type_version
+        self.input = input
+        self.task_list = task_list
+        self.retry_strategy = retry_strategy
+
+        default_id = self._default_id(workflow_type_name, workflow_type_version, input)
+        self.id_ = workflow_id or default_id 
+
+        
+

--- a/floto/specs/decider_spec.py
+++ b/floto/specs/decider_spec.py
@@ -8,7 +8,7 @@ class DeciderSpec:
     floto.decider.Deciders"""
 
     def __init__(self, domain=None, task_list=None, activity_tasks=None, activity_task_list=None,
-                 repeat_workflow=False):
+                 repeat_workflow=False, terminate_decider_after_completion=False):
         """
         Parameters
         ----------
@@ -27,6 +27,8 @@ class DeciderSpec:
         self.activity_tasks = activity_tasks
         self.activity_task_list = activity_task_list
         self.repeat_workflow = repeat_workflow
+        # TODO test
+        self.terminate_decider_after_completion = terminate_decider_after_completion
 
     def to_json(self):
         return json.dumps(self, cls=floto.specs.JSONEncoder, sort_keys=True)

--- a/floto/specs/json_encoder.py
+++ b/floto/specs/json_encoder.py
@@ -13,7 +13,8 @@ class JSONEncoder(json.JSONEncoder):
         if isinstance(obj, (floto.specs.ActivityTask,
                             floto.specs.DeciderSpec,
                             floto.specs.retry_strategy.Strategy,
-                            floto.specs.Timer)):
+                            floto.specs.Timer,
+                            floto.specs.ChildWorkflow)):
             return self.default_from_namespace(obj)
 
         if isinstance(obj, (dt.datetime,

--- a/floto/specs/task.py
+++ b/floto/specs/task.py
@@ -1,6 +1,14 @@
+import hashlib
+import json
+
 class Task(object):
     """Base class for tasks, e.g. ActivityTask, Timer."""
 
     def __init__(self, id_=None, requires=None):
         self.id_ = id_
         self.requires = requires
+
+    def _default_id(self, name, version, input):
+        input_string = json.dumps(input, sort_keys=True)
+        input_hash = hashlib.sha1(input_string.encode()).hexdigest()[:15]
+        return '{}:{}:{}'.format(name, version, input_hash)

--- a/floto/specs/task.py
+++ b/floto/specs/task.py
@@ -9,6 +9,13 @@ class Task(object):
         self.requires = requires
 
     def _default_id(self, name, version, input):
+        """Create a hexdigest from name, version, input (to be used as unique id)
+
+        Returns
+        -------
+        str
+
+        """
         input_string = json.dumps(input, sort_keys=True)
         input_hash = hashlib.sha1(input_string.encode()).hexdigest()[:15]
         return '{}:{}:{}'.format(name, version, input_hash)

--- a/tests/integration/deciders/test_01.py
+++ b/tests/integration/deciders/test_01.py
@@ -14,7 +14,8 @@ def test_01():
     decider_spec = DeciderSpec(domain='floto_test',
                                task_list=str(uuid.uuid4()),
                                activity_tasks=[activity_task_1],
-                               activity_task_list='floto_activities')
+                               activity_task_list='floto_activities',
+                               terminate_decider_after_completion=True)
 
     decider = floto.decider.Decider(decider_spec=decider_spec)
 

--- a/tests/integration/deciders/test_02.py
+++ b/tests/integration/deciders/test_02.py
@@ -14,7 +14,8 @@ def test_02():
     decider_spec = DeciderSpec(domain='floto_test',
                                task_list=str(uuid.uuid4()),
                                activity_tasks=[activity_task],
-                               activity_task_list='floto_activities')
+                               activity_task_list='floto_activities',
+                               terminate_decider_after_completion=True)
 
     decider = floto.decider.Decider(decider_spec=decider_spec)
 

--- a/tests/integration/deciders/test_03.py
+++ b/tests/integration/deciders/test_03.py
@@ -16,7 +16,8 @@ def test_03():
     decider_spec = DeciderSpec(domain='floto_test',
                                task_list=str(uuid.uuid4()),
                                activity_tasks=[a1, a2],
-                               activity_task_list='floto_activities')
+                               activity_task_list='floto_activities',
+                               terminate_decider_after_completion=True)
 
     decider = floto.decider.Decider(decider_spec=decider_spec)
 

--- a/tests/integration/deciders/test_04.py
+++ b/tests/integration/deciders/test_04.py
@@ -16,7 +16,8 @@ def test_04():
     decider_spec = DeciderSpec(domain='floto_test',
                                task_list=str(uuid.uuid4()),
                                activity_tasks=[a1, a3],
-                               activity_task_list='floto_activities')
+                               activity_task_list='floto_activities',
+                               terminate_decider_after_completion=True)
 
     decider = floto.decider.Decider(decider_spec=decider_spec)
 

--- a/tests/integration/deciders/test_05.py
+++ b/tests/integration/deciders/test_05.py
@@ -15,7 +15,8 @@ def test_05():
     decider_spec = DeciderSpec(domain='floto_test',
                                task_list=str(uuid.uuid4()),
                                activity_tasks=[activity_task],
-                               activity_task_list='floto_activities')
+                               activity_task_list='floto_activities',
+                               terminate_decider_after_completion=True)
 
     decider = floto.decider.Decider(decider_spec=decider_spec)
 

--- a/tests/integration/deciders/test_06.py
+++ b/tests/integration/deciders/test_06.py
@@ -14,7 +14,8 @@ def test_06():
     decider_spec = DeciderSpec(domain='floto_test',
                                task_list=str(uuid.uuid4()),
                                activity_tasks=[activity_task],
-                               activity_task_list='floto_activities')
+                               activity_task_list='floto_activities',
+                               terminate_decider_after_completion=True)
 
     decider = floto.decider.Decider(decider_spec=decider_spec)
 

--- a/tests/integration/deciders/test_07.py
+++ b/tests/integration/deciders/test_07.py
@@ -21,7 +21,8 @@ def test_07():
                                                            timer_b,
                                                            task_1,
                                                            task_2],
-                                           activity_task_list='floto_activities')
+                                           activity_task_list='floto_activities',
+                                           terminate_decider_after_completion=True)
 
     decider = floto.decider.Decider(decider_spec=decider_spec)
 

--- a/tests/integration/deciders/test_10.py
+++ b/tests/integration/deciders/test_10.py
@@ -15,7 +15,8 @@ def test_10():
     decider_spec = DeciderSpec(domain='floto_test',
                                task_list=str(uuid.uuid4()),
                                activity_tasks=[activity_task],
-                               activity_task_list='floto_activities')
+                               activity_task_list='floto_activities',
+                               terminate_decider_after_completion=True)
 
     decider = floto.decider.Decider(decider_spec=decider_spec)
 

--- a/tests/integration/deciders/test_11.py
+++ b/tests/integration/deciders/test_11.py
@@ -15,7 +15,8 @@ def test_11():
     decider_spec = DeciderSpec(domain='floto_test',
                                task_list=str(uuid.uuid4()),
                                activity_tasks=[activity_task_1],
-                               activity_task_list='floto_activities')
+                               activity_task_list='floto_activities',
+                               terminate_decider_after_completion=True)
 
     decider = SlowDecider(decider_spec)
 

--- a/tests/integration/deciders/test_12.py
+++ b/tests/integration/deciders/test_12.py
@@ -29,7 +29,7 @@ def test_12():
                                task_list=str(uuid.uuid4()),
                                activity_tasks=tasks,
                                activity_task_list='floto_activities',
-                               repeat_workflow=False)
+                               terminate_decider_after_completion=True)
 
     decider_1 = floto.decider.Decider(decider_spec=decider_spec)
     decider_2 = floto.decider.Decider(decider_spec=decider_spec)

--- a/tests/integration/deciders/test_13.py
+++ b/tests/integration/deciders/test_13.py
@@ -30,7 +30,7 @@ def test_13():
                                task_list=str(uuid.uuid4()),
                                activity_tasks=tasks,
                                activity_task_list='floto_activities',
-                               repeat_workflow=False)
+                               terminate_decider_after_completion=True)
 
     decider_1 = floto.decider.Decider(decider_spec=decider_spec)
     decider_2 = SlowDecider(decider_spec=decider_spec)

--- a/tests/integration/deciders/test_14.py
+++ b/tests/integration/deciders/test_14.py
@@ -1,0 +1,48 @@
+import time
+import uuid
+
+from test_helper import get_result
+
+import floto
+import floto.api
+import floto.decider
+from floto.specs import ActivityTask, DeciderSpec, ChildWorkflow
+from floto.specs.retry_strategy import InstantRetry
+
+
+def decider_spec_child_workflow():
+    rs = InstantRetry(retries=1)
+    task_1 = ActivityTask(name='activity1', version='v5', retry_strategy=rs)
+    decider_spec = DeciderSpec(domain='floto_test',
+                               task_list=str(uuid.uuid4()),
+                               activity_tasks=[task_1],
+                               activity_task_list='floto_activities',
+                               repeat_workflow=False)
+    return decider_spec
+
+def decider_spec_workflow():
+    rs = InstantRetry(retries=1)
+    child_workflow = ChildWorkflow(workflow_type_name='test_child_workflow', 
+            workflow_type_version='v1', retry_strategy=rs)
+    return child_workflow
+
+def test_14():
+    decider_workflow = floto.decider.Decider(decider_spec=decider_spec_workflow())
+    decider_child_workflow = floto.decider.Decider(decider_spec=decider_spec_child_workflow())
+
+    workflow_args = {'domain': decider_workflow.domain,
+                     'workflow_type_name': 'my_workflow_type',
+                     'workflow_type_version': 'v1',
+                     'task_list': decider_workflow.task_list}
+
+    response = floto.api.Swf().start_workflow_execution(**workflow_args)
+    run_id = response['runId']
+    workflow_id = 'my_workflow_type_v1'
+
+    print(30 * '-' + ' Running Test 14 ' + 30 * '-')
+    decider_child_workflow.run(separate_process=True)
+    decider_workflow.run()
+    result = get_result(decider_workflow.domain, run_id, workflow_id)
+    print(30 * '-' + ' Done Test 14    ' + 30 * '-')
+
+    return result

--- a/tests/integration/deciders/test_14.py
+++ b/tests/integration/deciders/test_14.py
@@ -12,9 +12,9 @@ from floto.specs.retry_strategy import InstantRetry
 
 def decider_spec_child_workflow():
     rs = InstantRetry(retries=1)
-    task_1 = ActivityTask(name='activity1', version='v5', retry_strategy=rs)
+    task_1 = ActivityTask(name='activity2', version='v4', retry_strategy=rs)
     decider_spec = DeciderSpec(domain='floto_test',
-                               task_list=str(uuid.uuid4()),
+                               task_list='child_workflow_task_list',
                                activity_tasks=[task_1],
                                activity_task_list='floto_activities',
                                repeat_workflow=False)
@@ -23,8 +23,12 @@ def decider_spec_child_workflow():
 def decider_spec_workflow():
     rs = InstantRetry(retries=1)
     child_workflow = ChildWorkflow(workflow_type_name='test_child_workflow', 
-            workflow_type_version='v1', retry_strategy=rs)
-    return child_workflow
+            workflow_type_version='v1', retry_strategy=rs, task_list='child_workflow_task_list')
+    decider_spec = DeciderSpec(domain='floto_test',
+                               task_list=str(uuid.uuid4()),
+                               activity_tasks=[child_workflow],
+                               repeat_workflow=False)
+    return decider_spec
 
 def test_14():
     decider_workflow = floto.decider.Decider(decider_spec=decider_spec_workflow())

--- a/tests/integration/deciders/test_15.py
+++ b/tests/integration/deciders/test_15.py
@@ -12,7 +12,7 @@ from floto.specs.retry_strategy import InstantRetry
 
 def decider_spec_child_workflow():
     rs = InstantRetry(retries=1)
-    task_1 = ActivityTask(name='activity2', version='v4', retry_strategy=rs)
+    task_1 = ActivityTask(name='activity1', version='v5', retry_strategy=rs)
     decider_spec = DeciderSpec(domain='floto_test',
                                task_list='child_workflow_task_list',
                                activity_tasks=[task_1],
@@ -22,31 +22,34 @@ def decider_spec_child_workflow():
 
 def decider_spec_workflow():
     rs = InstantRetry(retries=1)
+    task_1 = ActivityTask(name='activity1', version='v5', retry_strategy=rs)
     child_workflow = ChildWorkflow(workflow_type_name='test_child_workflow', 
-            workflow_type_version='v2', retry_strategy=rs, task_list='child_workflow_task_list')
+            workflow_type_version='v2', retry_strategy=rs, task_list='child_workflow_task_list',
+            requires=[task_1])
     decider_spec = DeciderSpec(domain='floto_test',
                                task_list=str(uuid.uuid4()),
-                               activity_tasks=[child_workflow],
+                               activity_tasks=[task_1, child_workflow],
                                terminate_decider_after_completion=True)
     return decider_spec
 
-def test_14():
+def test_15():
     decider_workflow = floto.decider.Decider(decider_spec=decider_spec_workflow())
     decider_child_workflow = floto.decider.Decider(decider_spec=decider_spec_child_workflow())
 
     workflow_args = {'domain': decider_workflow.domain,
                      'workflow_type_name': 'my_workflow_type',
                      'workflow_type_version': 'v1',
-                     'task_list': decider_workflow.task_list}
+                     'task_list': decider_workflow.task_list,
+                     'input':{'foo':'bar'}}
 
     response = floto.api.Swf().start_workflow_execution(**workflow_args)
     run_id = response['runId']
     workflow_id = 'my_workflow_type_v1'
 
-    print(30 * '-' + ' Running Test 14 ' + 30 * '-')
+    print(30 * '-' + ' Running Test 15 ' + 30 * '-')
     decider_child_workflow.run(separate_process=True)
     decider_workflow.run()
     result = get_result(decider_workflow.domain, run_id, workflow_id)
-    print(30 * '-' + ' Done Test 14    ' + 30 * '-')
+    print(30 * '-' + ' Done Test 15    ' + 30 * '-')
 
     return result

--- a/tests/integration/deciders/test_16.py
+++ b/tests/integration/deciders/test_16.py
@@ -1,7 +1,7 @@
 import time
 import uuid
 
-from test_helper import get_result
+from test_helper import get_fail_workflow_execution
 
 import floto
 import floto.api
@@ -11,13 +11,12 @@ from floto.specs.retry_strategy import InstantRetry
 
 
 def decider_spec_child_workflow():
-    rs = InstantRetry(retries=1)
-    task_1 = ActivityTask(name='activity2', version='v4', retry_strategy=rs)
+    task_1 = ActivityTask(name='activity_fails_2', version='v2')
     decider_spec = DeciderSpec(domain='floto_test',
                                task_list='child_workflow_task_list',
                                activity_tasks=[task_1],
                                activity_task_list='floto_activities',
-                               terminate_decider_after_completion=True)
+                               repeat_workflow=False)
     return decider_spec
 
 def decider_spec_workflow():
@@ -30,23 +29,25 @@ def decider_spec_workflow():
                                terminate_decider_after_completion=True)
     return decider_spec
 
-def test_14():
+def test_16():
     decider_workflow = floto.decider.Decider(decider_spec=decider_spec_workflow())
     decider_child_workflow = floto.decider.Decider(decider_spec=decider_spec_child_workflow())
 
     workflow_args = {'domain': decider_workflow.domain,
                      'workflow_type_name': 'my_workflow_type',
                      'workflow_type_version': 'v1',
-                     'task_list': decider_workflow.task_list}
+                     'task_list': decider_workflow.task_list,
+                     'input':{'foo':'bar'}}
 
     response = floto.api.Swf().start_workflow_execution(**workflow_args)
     run_id = response['runId']
     workflow_id = 'my_workflow_type_v1'
 
-    print(30 * '-' + ' Running Test 14 ' + 30 * '-')
+    print(30 * '-' + ' Running Test 16 ' + 30 * '-')
     decider_child_workflow.run(separate_process=True)
     decider_workflow.run()
-    result = get_result(decider_workflow.domain, run_id, workflow_id)
-    print(30 * '-' + ' Done Test 14    ' + 30 * '-')
+    decider_child_workflow._separate_process.terminate()
+    result = get_fail_workflow_execution(decider_workflow.domain, run_id, workflow_id)
+    print(30 * '-' + ' Done Test 16    ' + 30 * '-')
 
     return result

--- a/tests/integration/test_helper.py
+++ b/tests/integration/test_helper.py
@@ -1,8 +1,21 @@
 import json
 import time
+from functools import wraps
 
 import floto
 from floto.decider import Decider
+
+
+def docprint(func):
+    """Decorator that prints the docstring of the decorated function before executing it
+
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        print(func.__doc__)
+        return func(*args, **kwargs)
+
+    return wrapper
 
 
 def get_result(domain, run_id, workflow_id):

--- a/tests/integration/test_swf.py
+++ b/tests/integration/test_swf.py
@@ -1,3 +1,5 @@
+import json
+
 from deciders.test_01 import test_01
 from deciders.test_02 import test_02
 from deciders.test_03 import test_03
@@ -14,9 +16,9 @@ from deciders.test_13 import test_13
 from deciders.test_14 import test_14
 from deciders.test_15 import test_15
 from deciders.test_16 import test_16
+from test_helper import get_activity_result, docprint
 
 from activity_worker import ActivityWorkerProcess
-from test_helper import get_activity_result
 
 worker1 = ActivityWorkerProcess(domain='floto_test', task_list='floto_activities')
 worker2 = ActivityWorkerProcess(domain='floto_test', task_list='floto_activities')
@@ -24,125 +26,213 @@ worker1.start()
 worker2.start()
 
 
+@docprint
 def run_01():
-    # Single task with context
+    """
+    Test 01
+    Single task with context
+
+    """
     result = test_01()
     result = get_activity_result(result, 'activity1', 'v5')
+    print('Result: ' + json.dumps(result) + '\n')
     assert result['workflow'] == {'foo': 'bar'}
     assert result['status'] == 'finished'
 
 
+@docprint
 def run_02():
-    # Single task without context
+    """Test 01
+    Single task without context
+
+    """
     result = test_02()
     result = get_activity_result(result, 'activity2', 'v4')
+    print('Result: ' + json.dumps(result) + '\n')
     assert result['status'] == 'finished'
 
 
+@docprint
 def run_03():
-    # Two tasks without dependency, run in parallel if > 1 worker
+    """Test 03
+    Two tasks without dependency, run in parallel if > 1 worker
+
+    """
     result = test_03()
     result1 = get_activity_result(result, 'activity1', 'v5')
     result2 = get_activity_result(result, 'activity2', 'v4')
+    print('Result 1: ' + json.dumps(result1) + '\n')
+    print('Result 2: ' + json.dumps(result2) + '\n')
 
     assert result1['workflow'] == {'foo': 'bar'}
     assert result1['status'] == 'finished'
     assert result2['status'] == 'finished'
 
 
+@docprint
 def run_04():
-    # Two tasks with 1 -> 3
+    """Test 04
+    Two tasks with 1 -> 3
+
+    """
     result = test_04()
     result3 = get_activity_result(result, 'activity3', 'v2')
+    print('Result: ' + json.dumps(result) + '\n')
 
     assert result3['activity1']['status'] == 'finished'
     assert result3['activity1']['workflow'] == {'foo': 'bar'}
     assert result3['status'] == 'finished'
 
 
+@docprint
 def run_05():
-    # Failing task with retry strategy, succeeds after retry
+    """Test 05
+    Failing task with retry strategy, succeeds after retry
+
+    """
     result = test_05()
     result = get_activity_result(result, 'activity_fails_3', 'v2')
+    print('Result: ' + json.dumps(result) + '\n')
     assert result['workflow_input'] == {'foo': 'bar'}
     assert result['status'] == 'finished'
 
 
+@docprint
 def run_06():
-    # Failing task with retry strategy, reaches limit of retries
+    """Test 06
+    Failing task with retry strategy, reaches limit of retries
+
+    """
     details = test_06()
     details = get_activity_result(details, 'activity_fails_2', 'v2')
+    print('Result: ' + json.dumps(details) + '\n')
     assert details == 'Something went wrong'
 
 
+@docprint
 def run_07():
-    # Timeout
+    """Test 07
+    Timeout
+
+    """
     result = test_07()
     result = get_activity_result(result, 'activity2', 'v4')
+    print('Result: ' + json.dumps(result) + '\n')
     assert result['status'] == 'finished'
 
 
+@docprint
 def run_08():
-    # Repeated Workflow
+    """Test 08
+    Repeated Workflow
+
+    """
     result = test_08()
     result = get_activity_result(result, 'activity1', 'v5')
+    print('Result: ' + json.dumps(result) + '\n')
     assert result['status'] == 'finished'
 
 
+@docprint
 def run_09():
-    # Repeated Workflow with timer and failing activity with retries
+    """Test 09
+    Repeated Workflow with timer and failing activity with retries
+
+    """
     result = test_09()
     result = get_activity_result(result, 'activity4', 'v2')
+    print('Result: ' + json.dumps(result) + '\n')
     assert [r for r in result.keys() if 'activity1' in r]
     assert [r for r in result.keys() if 'activity2' in r]
 
 
+@docprint
 def run_10():
-    # Activity fails several times due to heartbeat timeout, succeeds after retry
-    # Might print warnings
+    """Test 10
+    Activity fails several times due to heartbeat timeout, succeeds after retry
+    Might print warnings
+    """
+
     result = test_10()
     result = get_activity_result(result, 'activity5', 'v1')
+    print('Result: ' + json.dumps(result) + '\n')
     assert result['sleep_time'] == 0
 
 
+@docprint
 def run_11():
-    # Decider times out, succeeds after next decision task
-    # Prints a warning due to Decider timeout
+    """Test 11
+    Decider times out, succeeds after next decision task
+    Prints a warning due to Decider timeout
+    """
+
     result = test_11()
     result = get_activity_result(result, 'activity1', 'v5')
+    print('Result: ' + json.dumps(result) + '\n')
     assert result['workflow'] == {'foo': 'bar'}
     assert result['status'] == 'finished'
 
 
+@docprint
 def run_12():
-    # run_09 with 2 parallel deciders
+    """Test 12
+    run_09 with 2 parallel deciders
+    """
+
     result = test_12()
     result = get_activity_result(result, 'activity4', 'v2')
+    print('Result: ' + json.dumps(result) + '\n')
     assert [r for r in result.keys() if 'activity1' in r]
     assert [r for r in result.keys() if 'activity2' in r]
 
 
+@docprint
 def run_13():
-    # Two parallel deciders, one of them times out
+    """Test 13
+    Two parallel deciders, one of them times out
+
+    """
     result = test_13()
     result = get_activity_result(result, 'activity4', 'v2')
+    print('Result: ' + json.dumps(result) + '\n')
     assert [r for r in result.keys() if 'activity1' in r]
     assert [r for r in result.keys() if 'activity2' in r]
 
+
+@docprint
 def run_14():
-    # Simple test with child workflow
+    """Test 14
+    Simple test with child workflow
+
+    """
     result = test_14()
     result = get_activity_result(result, 'test_child_workflow', 'v2')
+    print('Result: ' + json.dumps(result) + '\n')
     assert [r for r in result.keys() if 'activity2' in r]
 
+
+@docprint
 def run_15():
+    """Test 15
+
+    """
     result = test_15()
     result = get_activity_result(result, 'test_child_workflow', 'v2')
+    print('Result: ' + json.dumps(result) + '\n')
     assert result
 
+
+@docprint
 def run_16():
+    """Test 16
+    Failing Task in ChildWorkflow
+
+    """
     result = test_16()
+    result = get_activity_result(result, 'test_child_workflow', 'v2')
+    print('Result: ' + json.dumps(result) + '\n')
     assert result
+
 
 tests = [run_01, run_02, run_03, run_04, run_05, run_06, run_07, run_08, run_09, run_10, run_11,
          run_12, run_13, run_14, run_15, run_16]

--- a/tests/integration/test_swf.py
+++ b/tests/integration/test_swf.py
@@ -127,10 +127,16 @@ def run_13():
     assert [r for r in result.keys() if 'activity1' in r]
     assert [r for r in result.keys() if 'activity2' in r]
 
+def run_14():
+    # Simple test with child workflow
+    result = test_14()
+    print(result)
 
 tests = [run_01, run_02, run_03, run_04, run_05, run_06, run_07, run_08, run_09, run_10, run_11,
          run_12, run_13]
 
+tests = [run_14]
+       
 try:
     [t() for t in tests]
 except (KeyboardInterrupt, SystemExit):

--- a/tests/integration/test_swf.py
+++ b/tests/integration/test_swf.py
@@ -12,6 +12,8 @@ from deciders.test_11 import test_11
 from deciders.test_12 import test_12
 from deciders.test_13 import test_13
 from deciders.test_14 import test_14
+from deciders.test_15 import test_15
+from deciders.test_16 import test_16
 
 from activity_worker import ActivityWorkerProcess
 from test_helper import get_activity_result
@@ -130,13 +132,21 @@ def run_13():
 def run_14():
     # Simple test with child workflow
     result = test_14()
-    print(result)
+    result = get_activity_result(result, 'test_child_workflow', 'v2')
+    assert [r for r in result.keys() if 'activity2' in r]
+
+def run_15():
+    result = test_15()
+    result = get_activity_result(result, 'test_child_workflow', 'v2')
+    assert result
+
+def run_16():
+    result = test_16()
+    assert result
 
 tests = [run_01, run_02, run_03, run_04, run_05, run_06, run_07, run_08, run_09, run_10, run_11,
-         run_12, run_13]
+         run_12, run_13, run_14, run_15, run_16]
 
-tests = [run_14]
-       
 try:
     [t() for t in tests]
 except (KeyboardInterrupt, SystemExit):

--- a/tests/integration/test_swf.py
+++ b/tests/integration/test_swf.py
@@ -11,6 +11,7 @@ from deciders.test_10 import test_10
 from deciders.test_11 import test_11
 from deciders.test_12 import test_12
 from deciders.test_13 import test_13
+from deciders.test_14 import test_14
 
 from activity_worker import ActivityWorkerProcess
 from test_helper import get_activity_result
@@ -128,7 +129,7 @@ def run_13():
 
 
 tests = [run_01, run_02, run_03, run_04, run_05, run_06, run_07, run_08, run_09, run_10, run_11,
-         run_12]
+         run_12, run_13]
 
 try:
     [t() for t in tests]

--- a/tests/unit/decider/test_decider.py
+++ b/tests/unit/decider/test_decider.py
@@ -91,11 +91,11 @@ class TestDecider():
         info = {'executionInfo':{'workflowType':{'name':'wf_name', 'version':'v1'}}}
         mocker.patch('floto.decider.Base.get_workflow_execution_description', return_value=info)
         mocker.patch('floto.api.Swf.start_workflow_execution')
+        mocker.patch('floto.decider.DecisionInput.get_input_workflow', return_value='wf_input')
 
         decider.repeat_workflow = True
         decider.domain = 'd'
         decider.task_list = 'tl'
-        decider.decision_builder = type('obj', (object,), {'workflow_input':'wf_input'})
         decider.tear_down()
 
         expected_args = {'domain':'d',

--- a/tests/unit/decider/test_decider.py
+++ b/tests/unit/decider/test_decider.py
@@ -15,7 +15,8 @@ def task_2(task_1):
 @pytest.fixture
 def decider_spec(task_1, task_2):
     activity_tasks = [task_1, task_2]
-    decider_spec = DeciderSpec(domain='d', task_list='tl', activity_tasks=activity_tasks)
+    decider_spec = DeciderSpec(domain='d', task_list='tl', activity_tasks=activity_tasks,
+            terminate_decider_after_completion=True)
     return decider_spec 
 
 @pytest.fixture

--- a/tests/unit/decider/test_decision_builder.py
+++ b/tests/unit/decider/test_decision_builder.py
@@ -55,6 +55,11 @@ class TestDecisionBuilder(object):
         assert builder.get_decisions(history) == ['d']
         builder._collect_decisions.assert_called_once_with(0,3)
 
+    def test_set_history(self, builder):
+        builder._set_history('history')
+        assert builder.history == 'history'
+        assert builder.decision_input.history == 'history'
+
     @pytest.mark.parametrize('failed, completed, is_terminate',
             [(False, False, False),
              (False, True, True),
@@ -137,7 +142,6 @@ class TestDecisionBuilder(object):
                            'activityTaskScheduledEventAttributes':{}}
         mocker.patch('floto.History.get_id_activity_task_event', return_value='a_id')
         mocker.patch('floto.History.get_number_activity_task_failures', return_value=2)
-        mocker.patch('floto.History.get_event_task_scheduled', return_value=scheduled_event)
         builder.execution_graph._tasks_by_id = {'a_id':task_1}
         builder._set_history(empty_history)
         task_failed_event = {'eventId':4,
@@ -159,7 +163,6 @@ class TestDecisionBuilder(object):
                            'activityTaskScheduledEventAttributes':{}}
         mocker.patch('floto.History.get_id_activity_task_event', return_value='a_id')
         mocker.patch('floto.History.get_number_activity_task_failures', return_value=2)
-        mocker.patch('floto.History.get_event_task_scheduled', return_value=scheduled_event)
         builder.execution_graph._tasks_by_id = {'a_id':task_1}
         builder._set_history(empty_history)
         task_failed_event = {'eventId':4,

--- a/tests/unit/decider/test_decision_builder.py
+++ b/tests/unit/decider/test_decision_builder.py
@@ -272,7 +272,7 @@ class TestDecisionBuilder(object):
         mocker.patch('floto.decider.DecisionInput.get_input_task', return_value='i')
         d = builder.get_decision_schedule_activity(child_workflow_task)
         assert isinstance(d, floto.decisions.StartChildWorkflowExecution)
-        assert d._get_attribute('input') == 'i'
+        assert json.loads(d._get_attribute('input')) == 'i'
         assert 'wft_name' in d.workflow_id
 
     def test_get_decision_schedule_activity_with_timer(self, mocker, builder):
@@ -431,7 +431,7 @@ class TestDecisionBuilder(object):
         d = builder.get_decision_start_child_workflow_execution(child_workflow_task=cw_task, 
                 input_={'foo':'bar'})
         assert d.task_list['name'] == 'tl'
-        assert d._get_attribute('input') == {'foo':'bar'}
+        assert json.loads(d._get_attribute('input')) == {'foo':'bar'}
 
     def test_all_workflow_tasks_finished_depending_tasks(self, builder, mocker):
         mocker.patch('floto.decider.DecisionBuilder.completed_have_depending_tasks', 

--- a/tests/unit/decider/test_decision_input.py
+++ b/tests/unit/decider/test_decision_input.py
@@ -62,6 +62,17 @@ class TestDecisionInput:
     def test_get_input_task_unknow_type(self, di):
         assert not di.get_input_task('task')
 
+    def test_get_input_workflow(self, di, mocker):
+        mocker.patch('floto.History.get_workflow_input', return_value='wf_input')
+        di._workflow_input = None
+        i = di.get_input_workflow()
+        assert i == 'wf_input'
+
+    def test_store_input_workflow(self, di, mocker):
+        di._workflow_input = 'wf_input_stored'
+        i = di.get_input_workflow()
+        assert i == 'wf_input_stored'
+
     def test_get_input(self, di, task_1):
         i = di._get_input(task_1, 'activity_task')
         assert i['activity_task'] == {'task_1':'val'}
@@ -77,17 +88,6 @@ class TestDecisionInput:
         i = di._get_input(task_1, 'activity_task')
         assert i['activity_task'] == {'task_1':'val'}
         assert i['workflow'] == {'wf':'input'}
-
-    def test_get_input_workflow(self, di, mocker):
-        mocker.patch('floto.History.get_workflow_input', return_value='wf_input')
-        di._workflow_input = None
-        i = di.get_input_workflow()
-        assert i == 'wf_input'
-
-    def test_store_input_workflow(self, di, mocker):
-        di._workflow_input = 'wf_input_stored'
-        i = di.get_input_workflow()
-        assert i == 'wf_input_stored'
 
     def test_get_input_scheduled_task(self, di, mocker):
         scheduled_event = {'eventId':2, 

--- a/tests/unit/decider/test_decision_input.py
+++ b/tests/unit/decider/test_decision_input.py
@@ -1,0 +1,106 @@
+import pytest
+import floto.decider
+
+
+@pytest.fixture
+def task_1():
+    return floto.specs.ActivityTask(name='t', version='v1', input={'task_1':'val'})
+
+@pytest.fixture
+def task_2():
+    return floto.specs.ActivityTask(name='t2', version='v1', input={'task_2':'val'})
+
+@pytest.fixture
+def history(init_response):
+    return floto.History(domain='d', task_list='tl', response=init_response)
+
+@pytest.fixture
+def execution_graph(task_1):
+    return floto.decider.ExecutionGraph(activity_tasks=[task_1])
+
+@pytest.fixture
+def di(history, execution_graph):
+    di = floto.decider.DecisionInput(execution_graph=execution_graph)
+    di._workflow_input = {'wf':'input'}
+    di.history = history 
+    return di
+
+@pytest.fixture
+def child_workflow():
+    return floto.specs.ChildWorkflow(workflow_type_name='cw', workflow_type_version='v1')
+
+class TestDecisionInput:
+    def test_get_input_task_activity_task(self, di, task_1, mocker):
+        mocker.patch('floto.decider.DecisionInput._get_input')
+        di.get_input_task(task_1)
+        di._get_input.assert_called_once_with(task_1, 'activity_task')
+
+    def test_get_input_task_child_workflow(self, di, child_workflow, mocker):
+        mocker.patch('floto.decider.DecisionInput._get_input')
+        di.get_input_task(child_workflow)
+        di._get_input.assert_called_once_with(child_workflow, 'child_workflow_task')
+
+    def test_get_input_task_failed_task(self, di, task_1, mocker):
+        mocker.patch('floto.decider.DecisionInput._get_input_scheduled_task')
+        di.get_input_task(task_1, is_failed_task=True)
+        di._get_input_scheduled_task.assert_called_once_with(task_1.id_, 'ActivityTaskScheduled')
+
+    def test_get_input_task_failed_child_workflow(self, di, child_workflow, mocker):
+        mocker.patch('floto.decider.DecisionInput._get_input_scheduled_task')
+        di.get_input_task(child_workflow, is_failed_task=True)
+        di._get_input_scheduled_task.assert_called_once_with(child_workflow.id_, 
+                'StartChildWorkflowExecutionInitiated')
+
+    def test_get_workflow_result_wo_result(self, di, mocker):
+        mocker.patch('floto.History.get_result_completed_activity', return_value=None)
+        assert di.get_workflow_result() == None
+
+    def test_get_workflow_result(self, di, mocker, task_1):
+        mocker.patch('floto.History.get_result_completed_activity', return_value={'foo':'bar'})
+        assert di.get_workflow_result()[task_1.id_] == {'foo':'bar'}
+
+    def test_get_input_task_unknow_type(self, di):
+        assert not di.get_input_task('task')
+
+    def test_get_input(self, di, task_1):
+        i = di._get_input(task_1, 'activity_task')
+        assert i['activity_task'] == {'task_1':'val'}
+
+    def test_get_input_task_with_dependencies(self, di, task_1, task_2, mocker):
+        mocker.patch('floto.decider.ExecutionGraph.get_dependencies', return_value=[task_2])
+        mocker.patch('floto.History.get_result_completed_activity', return_value='result_task_2')
+        i = di._get_input(task_1, 'activity_task')
+        assert i['activity_task'] == {'task_1':'val'}
+        assert i[task_2.id_] == 'result_task_2'
+
+    def test_get_input_w_wf_input(self, di, task_1):
+        i = di._get_input(task_1, 'activity_task')
+        assert i['activity_task'] == {'task_1':'val'}
+        assert i['workflow'] == {'wf':'input'}
+
+    def test_get_input_workflow(self, di, mocker):
+        mocker.patch('floto.History.get_workflow_input', return_value='wf_input')
+        di._workflow_input = None
+        i = di.get_input_workflow()
+        assert i == 'wf_input'
+
+    def test_store_input_workflow(self, di, mocker):
+        di._workflow_input = 'wf_input_stored'
+        i = di.get_input_workflow()
+        assert i == 'wf_input_stored'
+
+    def test_get_input_scheduled_task(self, di, mocker):
+        scheduled_event = {'eventId':2, 
+                   'eventType':'ActivityTaskScheduled', 
+                   'activityTaskScheduledEventAttributes':{'input':'"my_input"'}}
+        mocker.patch('floto.History.get_event_by_task_id_and_type', return_value=scheduled_event)
+        i = di._get_input_scheduled_task('id', 'ActivityTaskScheduled')
+        assert i == 'my_input' 
+
+    def test_get_details_failed_tasks(self, mocker, di):
+        mocker.patch('floto.History.get_id_activity_task_event', return_value='a_id')
+        task_failed_event = {'eventType':'ActivityTaskFailed',
+                             'activityTaskFailedEventAttributes':{'details':'Error'}}
+        d = di.get_details_failed_tasks([task_failed_event])
+        assert d['a_id'] == 'Error'
+

--- a/tests/unit/decisions/test_decision.py
+++ b/tests/unit/decisions/test_decision.py
@@ -1,11 +1,22 @@
 import pytest
 import floto.decisions
 
-class TestDecision():
+@pytest.fixture
+def decision():
+    return floto.decisions.Decision()
 
-    @pytest.mark.xfail
-    def test_path_in_dictionary(self):
-        # TODO: move tests from test_schedule_activity_task here
-        assert False
+class TestDecision():
+    def test_path_in_dictionary(self, decision):
+        dictionary = {'key':'value'}
+        assert decision.path_in_dictionary(dictionary, 'key')
+        assert not decision.path_in_dictionary(dictionary, 'key2')
+
+    def test_path_in_dictionary_several_keys(self, decision):
+        dictionary = {'key':{'key2':'val'}}
+        assert decision.path_in_dictionary(dictionary, 'key.key2')
+
+    def test_path_in_dictionary_several_keys(self, decision):
+        dictionary = {'key':{'key2':'val'}}
+        assert decision.path_in_dictionary(dictionary, 'key.key2')
 
 

--- a/tests/unit/decisions/test_schedule_activity_task.py
+++ b/tests/unit/decisions/test_schedule_activity_task.py
@@ -24,22 +24,6 @@ class TestScheduleActivityTask():
         activity_id = activity_type.name + '_' + activity_type.version
         assert d.decision_attributes()['activityId'] == activity_id 
 
-    def test_path_in_dictionary(self):
-        dictionary = {'key':'value'}
-        d = ScheduleActivityTask()
-        assert d.path_in_dictionary(dictionary, 'key')
-        assert not d.path_in_dictionary(dictionary, 'key2')
-
-    def test_path_in_dictionary_several_keys(self):
-        dictionary = {'key':{'key2':'val'}}
-        d = ScheduleActivityTask()
-        assert d.path_in_dictionary(dictionary, 'key.key2')
-
-    def test_path_in_dictionary_several_keys(self):
-        dictionary = {'key':{'key2':'val'}}
-        d = ScheduleActivityTask()
-        assert d.path_in_dictionary(dictionary, 'key.key2')
-
     def test_assert_required_fields_raises(self):
         dictionary = {'key':'val'}
         d = ScheduleActivityTask()

--- a/tests/unit/decisions/test_start_child_workflow_execution.py
+++ b/tests/unit/decisions/test_start_child_workflow_execution.py
@@ -20,7 +20,7 @@ class TestStartChildWorkflowExecution():
         
     def test_init_input(self):
         w = floto.decisions.StartChildWorkflowExecution(input={'foo':'bar'}) 
-        assert w.get_attributes()['input'] == {'foo':'bar'} 
+        assert json.loads(w.get_attributes()['input']) == {'foo':'bar'} 
 
     def test_property_workflow_id(self):
         w = floto.decisions.StartChildWorkflowExecution() 
@@ -36,23 +36,5 @@ class TestStartChildWorkflowExecution():
         w = floto.decisions.StartChildWorkflowExecution() 
         w.workflow_type = floto.api.WorkflowType(name='n', version='v') 
         assert w.workflow_type == {'name':'n', 'version':'v'} 
-
-    #def test_from_json(self):
-        #j = '{"workflow_id": "my_child_workflow"}'
-        #w = floto.decisions.StartChildWorkflowExecution() 
-        #w.from_json(j)
-        #assert w.workflow_id == 'my_child_workflow'
-
-    #def test_json_serializablity(self):
-        #j = """{"startChildWorkflowExecutionDecisionAttributes":{
-                  #"workflowId":"my_id", 
-                  #"workflowType":{"name":"wft_name", "version":"wft_version"}}}"""
-        #w = floto.decisions.StartChildWorkflowExecution()
-        #w.from_json(j)
-        #d = w.get_decision()
-        #attributes = d['startChildWorkflowExecutionDecisionAttributes']
-        #assert d['decisionType'] == 'StartChildWorkflowExecution'
-        #assert attributes['workflowId'] == 'my_id' 
-        #assert attributes['workflowType']['name'] == 'wft_name' 
 
 

--- a/tests/unit/specs/test_activity_task.py
+++ b/tests/unit/specs/test_activity_task.py
@@ -14,4 +14,4 @@ class TestActivityTask(object):
 
     def test_init_wo_activity_id(self):
         t = floto.specs.ActivityTask(name='n', version='v')
-        assert t.id_ == t._default_activity_id()
+        assert t.id_ == t._default_id('n', 'v', None)

--- a/tests/unit/specs/test_child_workflow.py
+++ b/tests/unit/specs/test_child_workflow.py
@@ -1,0 +1,30 @@
+import pytest
+import floto.specs
+
+class TestChildWorkflow():
+    def test_init(self):
+        cw = floto.specs.ChildWorkflow(workflow_type_name='wft_name',
+                workflow_type_version='wft_version',
+                workflow_id='wid',
+                requires=['a'],
+                input={'foo':'bar'},
+                retry_strategy='retry_strategy')
+
+        assert cw.workflow_type_name == 'wft_name' 
+        assert cw.workflow_type_version == 'wft_version' 
+        assert cw.id_ == 'wid'
+        assert cw.requires == ['a']
+        assert cw.input == {'foo':'bar'}
+        assert cw.retry_strategy == 'retry_strategy'
+
+    def test_default_worfklow_id(self, mocker):
+        mocker.patch('floto.specs.Task._default_id', return_value='did')
+        cw = floto.specs.ChildWorkflow(workflow_type_name='wft_name',
+                workflow_type_version='wft_version',
+                input={'foo':'bar'})
+        floto.specs.Task._default_id.assert_called_once_with('wft_name', 'wft_version', 
+                {'foo':'bar'})
+        assert cw.id_ == 'did' 
+
+
+

--- a/tests/unit/specs/test_decider_spec.py
+++ b/tests/unit/specs/test_decider_spec.py
@@ -21,7 +21,8 @@ class TestDeciderSpec():
         assert j == json.dumps({'type':'floto.specs.DeciderSpec',
                                 'domain':'d',
                                 'activity_tasks':['t1'],
-                                'repeat_workflow':False}, 
+                                'repeat_workflow':False,
+                                'terminate_decider_after_completion':False}, 
                                sort_keys=True)
 
     def test_to_json_activity_task_list(self):

--- a/tests/unit/specs/test_json_encoder.py
+++ b/tests/unit/specs/test_json_encoder.py
@@ -61,6 +61,19 @@ class TestJSONEncoder(object):
         assert json_spec['type'] == 'floto.specs.Timer'
         assert json_spec['id_'] == 'my_timer'
 
+    def test_child_workflow_dump(self):
+        cw = floto.specs.ChildWorkflow(workflow_id='wid')
+        j = json.dumps(cw, cls=floto.specs.JSONEncoder)
+        json_spec = json.loads(j)
+        assert json_spec['type'] == 'floto.specs.ChildWorkflow'
+        assert json_spec['id_'] == 'wid'
+
+    def test_child_workflow_loads(self):
+        j = {'type':'floto.specs.ChildWorkflow', 'id_':'wid'}
+        cw = json.loads(json.dumps(j), object_hook=floto.specs.JSONEncoder.object_hook) 
+        assert isinstance(cw, floto.specs.ChildWorkflow)
+        assert cw.id_ == 'wid'
+
     def test_workflow_spec(self):
         tasks = [floto.specs.ActivityTask(name='n')]
         spec = floto.specs.DeciderSpec(activity_tasks=tasks)

--- a/tests/unit/specs/test_task.py
+++ b/tests/unit/specs/test_task.py
@@ -6,4 +6,11 @@ class TestTask(object):
         task = floto.specs.Task(id_='id', requires='r')
         assert task.id_ == 'id'
         assert task.requires == 'r'
+    
+    def test_default_id_wo_input(self):
+        t = floto.specs.Task()
+        assert t._default_id('n', 'v', None) == 'n:v:2be88ca4242c76e'
 
+    def test_default_id_w_input(self):
+        t = floto.specs.Task()
+        assert t._default_id('n', 'v', {'foo':'bar'}) == 'n:v:bc4919c6adf7168'


### PR DESCRIPTION
This is based on PR #4, adding
- `identity`: "name" for an activity worker that is shown in the SWF console, for easier diagnostics
- `docprint` decorator for the integration test functions
